### PR TITLE
Fix Browser project not executing due wrong selector

### DIFF
--- a/OpenSilver.Samples.Showcase.Browser/Program.cs
+++ b/OpenSilver.Samples.Showcase.Browser/Program.cs
@@ -16,7 +16,7 @@ namespace OpenSilver.Samples.Showcase.Browser
         public static async Task Main(string[] args)
         {
             var builder = WebAssemblyHostBuilder.CreateDefault(args);
-            builder.RootComponents.Add<App>("app");
+            builder.RootComponents.Add<App>("#app");
 
             builder.Services.AddTransient(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 


### PR DESCRIPTION
This will fix an error when executing the Browser project:
_Error: Could not find any element matching selector 'app'._