### PR TITLE
Improve Dark Mode colors (better separate the samples) + improve "View source" button style

### DIFF
--- a/src/App.xaml
+++ b/src/App.xaml
@@ -32,10 +32,18 @@
     <Application.Theme>
         <mt:ModernTheme CurrentPalette="Light">
             <mt:ModernTheme.LightPalette>
-                <mt:LightPalette BackgroundColor="#FFECECEC" ContainerBackgroundColor="#FFFFFFFF" PrimaryColor="#FF656565" />
+                <mt:LightPalette
+                    BackgroundColor="#FFFFFFFF"
+                    ContainerBackgroundColor="#FFFFFFFF"
+                    PrimaryColor="#FF656565" />
             </mt:ModernTheme.LightPalette>
             <mt:ModernTheme.DarkPalette>
-                <mt:DarkPalette BackgroundColor="#FF313131" ContainerBackgroundColor="#FF000000" PrimaryColor="#FF3C3C3C" BorderColor="#FF4A4444" />
+                <mt:DarkPalette
+                    BackgroundColor="#FF1C0809"
+                    ContainerBackgroundColor="#26FFFFFF"
+                    PrimaryColor="#FF555555"
+                    ControlBackgroundColor="#FF242424"
+                    BorderColor="#FF4A4444" />
             </mt:ModernTheme.DarkPalette>
         </mt:ModernTheme>
     </Application.Theme>

--- a/src/MainPage.xaml
+++ b/src/MainPage.xaml
@@ -127,7 +127,7 @@ mc:Ignorable="d"
 
             <!-- Menu -->
             <animations:AnimatedContentControl x:Name="MenuContainer" animations:Animation.OnAppear="{animations:FadeAndSlide Delay=2000, Direction=LeftToRight, Duration=500, Bounciness=0.3}" HorizontalAlignment="Left">
-                <Border x:Name="MenuBorder" Canvas.ZIndex="1" Width="240" Background="{DynamicResource Theme_ControlBackgroundBrush}">
+                <Border x:Name="MenuBorder" Canvas.ZIndex="1" Width="240" Background="{DynamicResource Theme_BackgroundBrush}">
                     <Border.Effect>
                         <DropShadowEffect ShadowDepth="3" Color="Black" BlurRadius="14" Opacity="0.15" />
                     </Border.Effect>
@@ -242,7 +242,7 @@ mc:Ignorable="d"
             </ScrollViewer>
         </Grid>
         <GridSplitter Grid.Row="2" x:Name="GridSplitter1" Background="LightGray" Visibility="Collapsed" Cursor="SizeNS" Height="5" HorizontalAlignment="Stretch"/>
-        <Grid Grid.Row="3" x:Name="SourceCodePane" Visibility="Collapsed" Background="{DynamicResource Theme_BorderBrush}">
+        <Grid Grid.Row="3" x:Name="SourceCodePane" Visibility="Collapsed" Background="{DynamicResource Theme_BackgroundBrush}">
             <TextBlock Text="Loading source code..." FontSize="14" Margin="20" HorizontalAlignment="Center" VerticalAlignment="Center" TextWrapping="Wrap"/>
             <Border x:Name="PlaceWhereSourceCodeWillBeDisplayed" Margin="0,10,0,0"/>
             <Button x:Name="ButtonToCloseSourceCode" Content="×" FontSize="20" FontWeight="Bold" Foreground="LightGray" Background="#FF6C6C6C" HorizontalAlignment="Right" HorizontalContentAlignment="Center" VerticalAlignment="Top" VerticalContentAlignment="Center" Padding="5,-2,4,2" Margin="5" Click="ButtonToCloseSourceCode_Click" />

--- a/src/Other/Styles.xaml
+++ b/src/Other/Styles.xaml
@@ -159,7 +159,6 @@
         <Setter Property="VerticalAlignment" Value="Top"/>
         <Setter Property="Background" Value="#FFE2E2E2"/>
         <Setter Property="Foreground" Value="White"/>
-        <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Margin" Value="10,15,4,2"/>
         <Setter Property="Padding" Value="12,4,12,4"/>
         <Setter Property="Cursor" Value="Hand"/>
@@ -169,60 +168,61 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
-                    <Border x:Name="OuterBorder"
-                            CornerRadius="10"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}">
+                    <Grid RenderTransformOrigin="0.5,0.5">
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup Name="CommonStates">
                                 <VisualState Name="Normal">
                                 </VisualState>
                                 <VisualState Name="MouseOver">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Background" Storyboard.TargetName="InnerBorder">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="#11000000"/>
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground" Storyboard.TargetName="MainTextBlock">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="White"/>
-                                        </ObjectAnimationUsingKeyFrames>
+                                        <DoubleAnimation To="1" Duration="00:00:00.15" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="OnHoverBackground"/>
+                                        <DoubleAnimation To="0" Duration="00:00:00.15" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="NormalBackground"/>
+                                        <ColorAnimation To="White" Duration="00:00:00.15" Storyboard.TargetProperty="Foreground.(SolidColorBrush.Color)" Storyboard.TargetName="MainTextBlock"/>
+                                        <DoubleAnimation Storyboard.TargetName="scaleTransform"
+                                                             Storyboard.TargetProperty="ScaleX"
+                                                             To="1.05"
+                                                             Duration="00:00:00.15"/>
+                                        <DoubleAnimation Storyboard.TargetName="scaleTransform"
+                                                             Storyboard.TargetProperty="ScaleY"
+                                                             To="1.05"
+                                                             Duration="00:00:00.15"/>
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState Name="Pressed">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Background" Storyboard.TargetName="InnerBorder">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="#22000000"/>
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground" Storyboard.TargetName="MainTextBlock">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="White"/>
-                                        </ObjectAnimationUsingKeyFrames>
+                                        <DoubleAnimation To="1" Duration="00:00:00.1" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="OnHoverBackground"/>
+                                        <DoubleAnimation To="0" Duration="00:00:00.1" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="NormalBackground"/>
+                                        <ColorAnimation To="White" Duration="00:00:00.1" Storyboard.TargetProperty="Foreground.(SolidColorBrush.Color)" Storyboard.TargetName="MainTextBlock"/>
+                                        <DoubleAnimation Storyboard.TargetName="scaleTransform"
+                                                             Storyboard.TargetProperty="ScaleX"
+                                                             To="0.95"
+                                                             Duration="00:00:00.1"/>
+                                        <DoubleAnimation Storyboard.TargetName="scaleTransform"
+                                                             Storyboard.TargetProperty="ScaleY"
+                                                             To="0.95"
+                                                             Duration="00:00:00.1"/>
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState Name="Disabled">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Background" Storyboard.TargetName="InnerBorder">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="#33FFFFFF"/>
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground" Storyboard.TargetName="MainTextBlock">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="White"/>
-                                        </ObjectAnimationUsingKeyFrames>
+                                        <ColorAnimation To="Gray" Duration="0" Storyboard.TargetProperty="Foreground.(SolidColorBrush.Color)" Storyboard.TargetName="NormalBackground"/>
+                                        <ColorAnimation To="White" Duration="0" Storyboard.TargetProperty="Foreground.(SolidColorBrush.Color)" Storyboard.TargetName="MainTextBlock"/>
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <Border x:Name="InnerBorder"
+                        <Grid.RenderTransform>
+                            <ScaleTransform x:Name="scaleTransform"/>
+                        </Grid.RenderTransform>
+                        <Border x:Name="OnHoverBackground"
                                 CornerRadius="10"
-                                Margin="-1"
-                                Background="{DynamicResource Theme_ControlBackgroundBrush}">
-                            <TextBlock x:Name="MainTextBlock" Text="{TemplateBinding Content}" Foreground="{TemplateBinding Background}" Margin="{TemplateBinding Padding}" TextDecorations="Underline" FontWeight="Bold"/>
-                            <!--<ContentPresenter x:Name="ContentPresenter"
-                                                ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                Content="{TemplateBinding Content}"
-                                                Margin="{TemplateBinding Padding}"
-                                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>-->
-                        </Border>
-                    </Border>
+                                Opacity="0"
+                                Background="{TemplateBinding Background}"/>
+                        <Border x:Name="NormalBackground"
+                                CornerRadius="10"
+                                Background="Transparent"/>
+                        <TextBlock x:Name="MainTextBlock" Text="{TemplateBinding Content}" Foreground="{TemplateBinding Background}" Margin="{TemplateBinding Padding}" TextDecorations="Underline" FontWeight="Bold"/>
+                    </Grid>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -396,5 +396,41 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+    </Style>
+    <Style x:Key="WelcomeTitle_Style" TargetType="ContentControl">
+        <Style.Setters>
+            <Setter Property="FontSize" Value="60"/>
+            <Setter Property="FontWeight" Value="Black"/>
+            <Setter Property="FontFamily" Value="{StaticResource InterFontFamily}"/>
+            <Setter Property="Margin" Value="21,20,10,20"/>
+            <Setter Property="HorizontalAlignment" Value="Left"/>
+            <Setter Property="Background" Value="{DynamicResource Theme_BackgroundBrush}"/>
+            <Setter Property="Foreground">
+                <Setter.Value>
+                    <LinearGradientBrush StartPoint="0,0" EndPoint="1,0">
+                        <GradientStop Offset="0" Color="#FF3288F1"/>
+                        <GradientStop Offset="0.2" Color="#FF9442FD"/>
+                        <GradientStop Offset="0.4" Color="#FFC534CD"/>
+                        <GradientStop Offset="0.6" Color="#FFEE3881"/>
+                        <GradientStop Offset="0.8" Color="#FFFB7434"/>
+                        <GradientStop Offset="1" Color="#FFFFB200"/>
+                    </LinearGradientBrush>
+                </Setter.Value>
+            </Setter>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ContentControl">
+                        <Viewbox Stretch="Uniform" StretchDirection="DownOnly" HorizontalAlignment="Stretch">
+                            <Border Background="{TemplateBinding Background}" CornerRadius="50">
+                                <Border.Effect>
+                                    <DropShadowEffect ShadowDepth="3" Color="Black" BlurRadius="30" Opacity="0.2" />
+                                </Border.Effect>
+                                <ContentPresenter Margin="40,12,40,12"/>
+                            </Border>
+                        </Viewbox>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style.Setters>
     </Style>
 </ResourceDictionary>

--- a/src/Samples/Welcome.xaml
+++ b/src/Samples/Welcome.xaml
@@ -7,9 +7,9 @@
     <Grid>
         <local:JsParticlesEffect animations:Animation.OnAppear="{animations:FadeAndScale Delay=500, Duration=1000}"/>
         <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
-            <ContentControl Content="Welcome!" animations:Animation.OnAppear="{animations:FadeAndScale Delay=500, Duration=1000, Bounciness=1}" HorizontalAlignment="Center" Style="{StaticResource PageHeader_Style}"/>
+            <ContentControl Content="Welcome!" animations:Animation.OnAppear="{animations:FadeAndScale Delay=500, Duration=1000, Bounciness=1}" HorizontalAlignment="Center" Background="{DynamicResource Theme_ControlBackgroundBrush}" Style="{StaticResource WelcomeTitle_Style}"/>
             <animations:AnimatedContentControl animations:Animation.OnAppear="{animations:FadeAndScale Delay=2700, Duration=500, Bounciness=0.3}">
-                <Border Background="{DynamicResource Theme_ContainerBackgroundBrush}" CornerRadius="30" MaxWidth="530" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="40,0,40,20">
+                <Border Background="{DynamicResource Theme_ControlBackgroundBrush}" CornerRadius="30" MaxWidth="530" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="40,0,40,20">
                     <Border.Effect>
                         <DropShadowEffect ShadowDepth="3" Color="Black" BlurRadius="20" Opacity="0.2" />
                     </Border.Effect>

--- a/src/Samples/XAML_Controls/ListBox/ListBox_Demo.xaml
+++ b/src/Samples/XAML_Controls/ListBox/ListBox_Demo.xaml
@@ -13,7 +13,7 @@
             </Grid.RowDefinitions>
             <ContentControl Content="ListBox" Foreground="#FF6F7DFF" Background="#FF9A9FCE" Style="{StaticResource HeaderControl_Style}"/>
             <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
-                <ListBox x:Name="ListBox1" DisplayMemberPath="Name" SelectedValuePath="ImagePath" VerticalAlignment="Top" SelectionMode="Single" BorderThickness="1" BorderBrush="LightGray"/>
+                <ListBox x:Name="ListBox1" DisplayMemberPath="Name" SelectedValuePath="ImagePath" VerticalAlignment="Top" SelectionMode="Single" BorderThickness="1" BorderBrush="{DynamicResource Theme_BorderBrush}"/>
                 <Image Source="{Binding ElementName=ListBox1, Path=SelectedValue}" Width="60" Height="60" Margin="5,0,0,0" VerticalAlignment="Top"/>
             </StackPanel>
             <local:ViewSourceButton Grid.Row="2"

--- a/src/Samples/XAML_Features/Drag_And_Drop/Drag_And_Drop_Demo_Silverlight.xaml
+++ b/src/Samples/XAML_Features/Drag_And_Drop/Drag_And_Drop_Demo_Silverlight.xaml
@@ -70,19 +70,19 @@
                              FontSize="12"
                              ItemsSource="{x:Static local:Planet.Planets}"/>
                 </ListBoxDragDropTarget>
-                <TreeViewDragDropTarget Grid.Row="1"
-                                        Grid.Column="1"
-                                        HorizontalContentAlignment="Stretch"
-                                        VerticalContentAlignment="Stretch"
-                                        AllowDrop="True">
-                    <TreeView Background="{DynamicResource Theme_ControlBackgroundBrush}">
-                        <TreeView.ItemTemplate>
-                            <HierarchicalDataTemplate>
-                                <TextBlock FontSize="12" Text="{Binding Name}"/>
-                            </HierarchicalDataTemplate>
-                        </TreeView.ItemTemplate>
-                    </TreeView>
-                </TreeViewDragDropTarget>
+                <Border Grid.Row="1" Grid.Column="1" CornerRadius="4" Margin="4,0,0,0" BorderThickness="1" BorderBrush="{DynamicResource Theme_BorderBrush}">
+                    <TreeViewDragDropTarget HorizontalContentAlignment="Stretch"
+                                            VerticalContentAlignment="Stretch"
+                                            AllowDrop="True">
+                        <TreeView Background="{DynamicResource Theme_ControlBackgroundBrush}">
+                            <TreeView.ItemTemplate>
+                                <HierarchicalDataTemplate>
+                                    <TextBlock FontSize="12" Text="{Binding Name}"/>
+                                </HierarchicalDataTemplate>
+                            </TreeView.ItemTemplate>
+                        </TreeView>
+                    </TreeViewDragDropTarget>
+                </Border>
             </Grid>
 
             <local:ViewSourceButton Grid.Row="3" Background="#FFC7C228">


### PR DESCRIPTION
The main goal of this PR is to better separate the samples from each other (ie. make it easier to distinguish what element belongs to which sample).

On a smaller note, the "View Source" button now has a transparent background (useful in dark mode) and an animation. Also, the background color of the "View Source" panel (which shows the code) has been fine-tuned.

**BEFORE:**

![image](https://github.com/user-attachments/assets/ed1a896b-1ea2-4985-a73c-80ba6ca7a01b)

**AFTER:**

![image](https://github.com/user-attachments/assets/f4c8d43a-5f5f-449b-ad8c-dae28105f263)

**BEFORE:**

![image](https://github.com/user-attachments/assets/9ebedbbe-02e2-4b14-8258-7638597c40df)

**AFTER:**

![image](https://github.com/user-attachments/assets/cd4a85fa-9542-476b-8e7d-198d05044608)

