### PR TITLE
Display "Loading..." message while a page is loading

### DIFF
--- a/src/OpenSilver.Samples.Showcase.csproj
+++ b/src/OpenSilver.Samples.Showcase.csproj
@@ -24,6 +24,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Page Include="Other\Controls\LoadingControl.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Other\Internals\Search\SearchControl.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -236,11 +239,13 @@
     </Page>
     <Compile Include="Other\Contact.cs" />
     <Compile Include="Other\Controls\JsParticlesEffect.cs" />
+    <Compile Include="Other\Controls\LoadingControl.xaml.cs" />
     <Compile Include="Other\Controls\SvgImage.cs" />
     <Compile Include="Other\Converters\EnumToListConverter.cs" />
     <Compile Include="Other\Converters\StringEmptyToVisibilityConverter.cs" />
     <Compile Include="Other\Converters\RgbToBrushConverter.cs" />
     <Compile Include="Other\Elements.cs" />
+    <Compile Include="Other\Internals\ItemsControlLoadingBehavior.cs" />
     <Compile Include="Other\Internals\Search\SamplesInfoLoader.cs" />
     <Compile Include="Other\Internals\Search\ControlSearch.cs" />
     <Compile Include="Other\Internals\Search\SearchableItem.cs" />

--- a/src/OpenSilver.Samples.Showcase.fsproj
+++ b/src/OpenSilver.Samples.Showcase.fsproj
@@ -28,7 +28,7 @@
 		<Compile Include="Other\Controls\SvgImage.fs" />
 		<Compile Include="Other\Converters\EnumToListConverter.fs" />
 		<Compile Include="Other\Converters\RgbToBrushConverter.fs" />
-		<Compile Include="Other\Converters\StringEmptyToVisibilityConverter.fs" />		
+		<Compile Include="Other\Converters\StringEmptyToVisibilityConverter.fs" />	
 		<Compile Include="Other\MarkupExtensions\ResxExtension.fs" />
 		<Compile Include="Other\PageInfo.fs" />
 		<Compile Include="Samples\Interop_Samples\HtmlPresenter\HtmlColorPicker.fs" />
@@ -75,6 +75,13 @@
     <Compile Include="Other\Internals\ViewSourceButtonInfo.fs" />
     <Compile Include="Other\Internals\ViewStyleSourceInfo.fs" />
     <Compile Include="Other\Internals\ViewModernStyleSourceInfo.fs" />
+    <Page Include="Other\Controls\LoadingControl.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Compile Include="Other\Controls\LoadingControl.xaml.fs">
+      <DependentUpon>Other\Controls\LoadingControl.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Other\Internals\ItemsControlLoadingBehavior.fs" />
     <Page Include="Other\Internals\ViewSourcePanel.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/OpenSilver.Samples.Showcase.vbproj
+++ b/src/OpenSilver.Samples.Showcase.vbproj
@@ -29,6 +29,9 @@
   </ItemGroup>
   
   <ItemGroup>
+    <Page Include="Other\Controls\LoadingControl.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Other\Internals\Search\SearchControl.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -239,11 +242,13 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Compile Include="Other\Controls\JsParticlesEffect.vb" />
+    <Compile Include="Other\Controls\LoadingControl.xaml.vb" />
     <Compile Include="Other\Controls\SvgImage.vb" />
     <Compile Include="Other\Converters\EnumToListConverter.vb" />
     <Compile Include="Other\Converters\RgbToBrushConverter.vb" />
     <Compile Include="Other\Converters\StringEmptyToVisibilityConverter.vb" />
     <Compile Include="Other\Elements.vb" />
+    <Compile Include="Other\Internals\ItemsControlLoadingBehavior.vb" />
     <Compile Include="Other\Internals\Search\ControlSearch.vb" />
     <Compile Include="Other\Internals\Search\SamplesInfoLoader.vb" />
     <Compile Include="Other\Internals\Search\SearchableItem.vb" />

--- a/src/Other/Controls/LoadingControl.xaml
+++ b/src/Other/Controls/LoadingControl.xaml
@@ -1,0 +1,31 @@
+﻿<UserControl
+    x:Class="OpenSilver.Samples.Showcase.LoadingControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="clr-namespace:OpenSilver.Samples.Showcase"
+    xmlns:animations="clr-namespace:OpenSilver.Animations;assembly=OpenSilver.Animations"
+    IsHitTestVisible="False">
+
+    <Grid   HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            animations:Animation.OnAppear="{animations:FadeAndScale Bounciness=0.3, Delay=1000}">
+        <Border Background="{DynamicResource Theme_TextBrush}"
+                Opacity="0.6"
+                CornerRadius="20">
+            <Border.Effect>
+                <DropShadowEffect
+                        Color="Black"
+                        Direction="320"
+                        ShadowDepth="5"
+                        Opacity="0.5"
+                        BlurRadius="10" />
+            </Border.Effect>
+        </Border>
+        <TextBlock  FontSize="26"
+                    Foreground="{DynamicResource Theme_BackgroundBrush}"
+                    FontWeight="Bold"
+                    animations:Animation.OnAppear="{animations:FadeAndScale Bounciness=0.3, Delay=1000}"
+                    TextAlignment="Center"
+                    Margin="30,20">Loading<LineBreak/>Please wait...</TextBlock>
+    </Grid>
+</UserControl>

--- a/src/Other/Controls/LoadingControl.xaml.cs
+++ b/src/Other/Controls/LoadingControl.xaml.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Data;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Navigation;
+
+namespace OpenSilver.Samples.Showcase
+{
+    public partial class LoadingControl : UserControl
+    {
+        public LoadingControl()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/Other/Controls/LoadingControl.xaml.fs
+++ b/src/Other/Controls/LoadingControl.xaml.fs
@@ -1,0 +1,6 @@
+﻿namespace OpenSilver.Samples.Showcase
+
+type LoadingControl() as this =
+    inherit LoadingControlXaml()
+    do
+        this.InitializeComponent()

--- a/src/Other/Controls/LoadingControl.xaml.vb
+++ b/src/Other/Controls/LoadingControl.xaml.vb
@@ -1,0 +1,11 @@
+﻿Imports System.Windows.Controls
+
+Namespace OpenSilver.Samples.Showcase
+    Partial Public Class LoadingControl
+        Inherits UserControl
+
+        Public Sub New()
+            InitializeComponent()
+        End Sub
+    End Class
+End Namespace

--- a/src/Other/Internals/ItemsControlLoadingBehavior.cs
+++ b/src/Other/Internals/ItemsControlLoadingBehavior.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Media;
+using System.Windows.Media.Effects;
+
+namespace OpenSilver.Samples.Showcase
+{
+    public static class ItemsControlLoadingBehavior
+    {
+        // Public attached property
+        public static readonly DependencyProperty ShowLoadingOnGeneratingProperty =
+            DependencyProperty.RegisterAttached(
+                "ShowLoadingOnGenerating",
+                typeof(bool),
+                typeof(ItemsControlLoadingBehavior),
+                new PropertyMetadata(false, OnShowLoadingOnGeneratingChanged)
+            );
+
+        public static void SetShowLoadingOnGenerating(DependencyObject element, bool value) =>
+            element.SetValue(ShowLoadingOnGeneratingProperty, value);
+
+        public static bool GetShowLoadingOnGenerating(DependencyObject element) =>
+            (bool)element.GetValue(ShowLoadingOnGeneratingProperty);
+
+        // Private attached properties to hold our handler & popup per-control
+        private static readonly DependencyProperty StatusChangedHandlerProperty =
+            DependencyProperty.RegisterAttached(
+                "StatusChangedHandler",
+                typeof(EventHandler),
+                typeof(ItemsControlLoadingBehavior),
+                null
+            );
+
+        private static readonly DependencyProperty LoadingPopupProperty =
+            DependencyProperty.RegisterAttached(
+                "LoadingPopup",
+                typeof(Popup),
+                typeof(ItemsControlLoadingBehavior),
+                null
+            );
+
+        private static void OnShowLoadingOnGeneratingChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (!(d is ItemsControl itemsControl))
+                return;
+
+            bool enabled = (bool)e.NewValue;
+            if (enabled)
+            {
+                // attach
+                EventHandler handler = (s, args) => OnStatusChanged(itemsControl);
+                itemsControl.SetValue(StatusChangedHandlerProperty, handler);
+                itemsControl.ItemContainerGenerator.StatusChanged += handler;
+            }
+            else
+            {
+                // detach
+                var handler = (EventHandler)itemsControl.GetValue(StatusChangedHandlerProperty);
+                if (handler != null)
+                {
+                    itemsControl.ItemContainerGenerator.StatusChanged -= handler;
+                    itemsControl.ClearValue(StatusChangedHandlerProperty);
+                }
+
+                // ensure any popup is closed
+                var existing = (Popup)itemsControl.GetValue(LoadingPopupProperty);
+                if (existing != null)
+                {
+                    existing.IsOpen = false;
+                    itemsControl.ClearValue(LoadingPopupProperty);
+                }
+            }
+        }
+
+        private static void OnStatusChanged(ItemsControl itemsControl)
+        {
+            var status = itemsControl.ItemContainerGenerator.Status;
+
+            if (status == GeneratorStatus.GeneratingContainers)
+            {
+                // create & show
+                var popup = new Popup
+                {
+                    Child = new LoadingControl(),
+                    Placement = PlacementMode.Absolute,
+                    IsHitTestVisible = false,
+                    IsOpen = false
+                };
+
+                /*
+                // size & position to overlay the ItemsControl
+                var root = Application.Current.RootVisual as FrameworkElement;
+                var transform = itemsControl.TransformToVisual(root);
+                var topLeft = transform.Transform(new Point(0, 0));
+                popup.HorizontalOffset = topLeft.X;
+                popup.VerticalOffset = topLeft.Y;
+                popup.Width = itemsControl.ActualWidth;
+                popup.Height = itemsControl.ActualHeight;
+                */
+
+                // size & position to overlay the whole window
+                var host = (FrameworkElement)Application.Current.RootVisual;
+                popup.Width = host.ActualWidth;
+                popup.Height = host.ActualHeight;
+
+                itemsControl.SetValue(LoadingPopupProperty, popup);
+                popup.IsOpen = true;
+            }
+            else
+            {
+                // close & cleanup
+                var popup = (Popup)itemsControl.GetValue(LoadingPopupProperty);
+                if (popup != null)
+                {
+                    popup.IsOpen = false;
+                    itemsControl.ClearValue(LoadingPopupProperty);
+                }
+            }
+        }
+    }
+}

--- a/src/Other/Internals/ItemsControlLoadingBehavior.fs
+++ b/src/Other/Internals/ItemsControlLoadingBehavior.fs
@@ -1,0 +1,85 @@
+﻿namespace OpenSilver.Samples.Showcase
+
+open System
+open System.Windows
+open System.Windows.Controls
+open System.Windows.Controls.Primitives
+
+module ItemsControlLoadingBehavior =
+    let ShowLoadingOnGenerating = false
+
+//[<AutoOpen>]
+//module ItemsControlLoadingBehaviorModule =
+
+//    let statusChangedHandlerProperty =
+//        DependencyProperty.RegisterAttached(
+//            "StatusChangedHandler",
+//            typeof<EventHandler>,
+//            typeof<ItemsControlLoadingBehavior>,
+//            null
+//        )
+
+//    let loadingPopupProperty =
+//        DependencyProperty.RegisterAttached(
+//            "LoadingPopup",
+//            typeof<Popup>,
+//            typeof<ItemsControlLoadingBehavior>,
+//            null
+//        )
+
+//    let rec onStatusChanged (itemsControl: ItemsControl) =
+//        match itemsControl.ItemContainerGenerator.Status with
+//        | GeneratorStatus.GeneratingContainers ->
+//            let popup = Popup()
+//            popup.Child <- new LoadingControl()
+//            popup.Placement <- PlacementMode.Absolute
+//            popup.IsHitTestVisible <- false
+//            popup.IsOpen <- false
+
+//            let host = Application.Current.RootVisual :?> FrameworkElement
+//            popup.Width <- host.ActualWidth
+//            popup.Height <- host.ActualHeight
+
+//            itemsControl.SetValue(loadingPopupProperty, popup)
+//            popup.IsOpen <- true
+//        | _ ->
+//            match itemsControl.GetValue(loadingPopupProperty) with
+//            | :? Popup as popup ->
+//                popup.IsOpen <- false
+//                itemsControl.ClearValue(loadingPopupProperty)
+//            | _ -> ()
+
+//    let ShowLoadingOnGeneratingProperty =
+//        DependencyProperty.RegisterAttached(
+//            "ShowLoadingOnGenerating",
+//            typeof<bool>,
+//            typeof<ItemsControlLoadingBehavior>,
+//            PropertyMetadata(false, PropertyChangedCallback(fun d e ->
+//                match d with
+//                | :? ItemsControl as ic ->
+//                    let enabled = e.NewValue :?> bool
+//                    if enabled then
+//                        let handler = EventHandler(fun _ _ -> onStatusChanged ic)
+//                        ic.SetValue(statusChangedHandlerProperty, handler)
+//                        ic.ItemContainerGenerator.StatusChanged.AddHandler(handler)
+//                    else
+//                        match ic.GetValue(statusChangedHandlerProperty) with
+//                        | :? EventHandler as handler ->
+//                            ic.ItemContainerGenerator.StatusChanged.RemoveHandler(handler)
+//                            ic.ClearValue(statusChangedHandlerProperty)
+//                        | _ -> ()
+
+//                        match ic.GetValue(loadingPopupProperty) with
+//                        | :? Popup as popup ->
+//                            popup.IsOpen <- false
+//                            ic.ClearValue(loadingPopupProperty)
+//                        | _ -> ()
+//                | _ -> ()
+//            ))
+//        )
+
+//    let SetShowLoadingOnGenerating (element: DependencyObject) (value: bool) =
+//        element.SetValue(ShowLoadingOnGeneratingProperty, value)
+
+//    let GetShowLoadingOnGenerating (element: DependencyObject) =
+//        element.GetValue(ShowLoadingOnGeneratingProperty) :?> bool

--- a/src/Other/Internals/ItemsControlLoadingBehavior.fs
+++ b/src/Other/Internals/ItemsControlLoadingBehavior.fs
@@ -5,81 +5,77 @@ open System.Windows
 open System.Windows.Controls
 open System.Windows.Controls.Primitives
 
-module ItemsControlLoadingBehavior =
-    let ShowLoadingOnGenerating = false
+type ItemsControlLoadingBehavior() =
 
-//[<AutoOpen>]
-//module ItemsControlLoadingBehaviorModule =
+    static let statusChangedHandlerProperty =
+        DependencyProperty.RegisterAttached(
+            "StatusChangedHandler",
+            typeof<bool>,
+            typeof<ItemsControlLoadingBehavior>,
+            null
+        )
 
-//    let statusChangedHandlerProperty =
-//        DependencyProperty.RegisterAttached(
-//            "StatusChangedHandler",
-//            typeof<EventHandler>,
-//            typeof<ItemsControlLoadingBehavior>,
-//            null
-//        )
+    static let loadingPopupProperty =
+        DependencyProperty.RegisterAttached(
+            "LoadingPopup",
+            typeof<Popup>,
+            typeof<ItemsControlLoadingBehavior>,
+            null
+        )
 
-//    let loadingPopupProperty =
-//        DependencyProperty.RegisterAttached(
-//            "LoadingPopup",
-//            typeof<Popup>,
-//            typeof<ItemsControlLoadingBehavior>,
-//            null
-//        )
+    static let rec onStatusChanged (itemsControl: ItemsControl) =
+        match itemsControl.ItemContainerGenerator.Status with
+        | GeneratorStatus.GeneratingContainers ->
+            let popup = Popup()
+            popup.Child <- new LoadingControl()
+            popup.Placement <- PlacementMode.Absolute
+            popup.IsHitTestVisible <- false
+            popup.IsOpen <- false
 
-//    let rec onStatusChanged (itemsControl: ItemsControl) =
-//        match itemsControl.ItemContainerGenerator.Status with
-//        | GeneratorStatus.GeneratingContainers ->
-//            let popup = Popup()
-//            popup.Child <- new LoadingControl()
-//            popup.Placement <- PlacementMode.Absolute
-//            popup.IsHitTestVisible <- false
-//            popup.IsOpen <- false
+            let host = Application.Current.RootVisual :?> FrameworkElement
+            popup.Width <- host.ActualWidth
+            popup.Height <- host.ActualHeight
 
-//            let host = Application.Current.RootVisual :?> FrameworkElement
-//            popup.Width <- host.ActualWidth
-//            popup.Height <- host.ActualHeight
+            itemsControl.SetValue(loadingPopupProperty, popup)
+            popup.IsOpen <- true
+        | _ ->
+            match itemsControl.GetValue(loadingPopupProperty) with
+            | :? Popup as popup ->
+                popup.IsOpen <- false
+                itemsControl.ClearValue(loadingPopupProperty)
+            | _ -> ()
 
-//            itemsControl.SetValue(loadingPopupProperty, popup)
-//            popup.IsOpen <- true
-//        | _ ->
-//            match itemsControl.GetValue(loadingPopupProperty) with
-//            | :? Popup as popup ->
-//                popup.IsOpen <- false
-//                itemsControl.ClearValue(loadingPopupProperty)
-//            | _ -> ()
+    static let ShowLoadingOnGeneratingProperty =
+        DependencyProperty.RegisterAttached(
+            "ShowLoadingOnGenerating",
+            typeof<bool>,
+            typeof<ItemsControlLoadingBehavior>,
+            PropertyMetadata(false, PropertyChangedCallback(fun d e ->
+                match d with
+                | :? ItemsControl as ic ->
+                    let enabled = e.NewValue :?> bool
+                    if enabled then
+                        let handler = EventHandler(fun _ _ -> onStatusChanged ic)
+                        ic.SetValue(statusChangedHandlerProperty, handler)
+                        ic.ItemContainerGenerator.StatusChanged.AddHandler(handler)
+                    else
+                        match ic.GetValue(statusChangedHandlerProperty) with
+                        | :? EventHandler as handler ->
+                            ic.ItemContainerGenerator.StatusChanged.RemoveHandler(handler)
+                            ic.ClearValue(statusChangedHandlerProperty)
+                        | _ -> ()
 
-//    let ShowLoadingOnGeneratingProperty =
-//        DependencyProperty.RegisterAttached(
-//            "ShowLoadingOnGenerating",
-//            typeof<bool>,
-//            typeof<ItemsControlLoadingBehavior>,
-//            PropertyMetadata(false, PropertyChangedCallback(fun d e ->
-//                match d with
-//                | :? ItemsControl as ic ->
-//                    let enabled = e.NewValue :?> bool
-//                    if enabled then
-//                        let handler = EventHandler(fun _ _ -> onStatusChanged ic)
-//                        ic.SetValue(statusChangedHandlerProperty, handler)
-//                        ic.ItemContainerGenerator.StatusChanged.AddHandler(handler)
-//                    else
-//                        match ic.GetValue(statusChangedHandlerProperty) with
-//                        | :? EventHandler as handler ->
-//                            ic.ItemContainerGenerator.StatusChanged.RemoveHandler(handler)
-//                            ic.ClearValue(statusChangedHandlerProperty)
-//                        | _ -> ()
+                        match ic.GetValue(loadingPopupProperty) with
+                        | :? Popup as popup ->
+                            popup.IsOpen <- false
+                            ic.ClearValue(loadingPopupProperty)
+                        | _ -> ()
+                | _ -> ()
+            ))
+        )
 
-//                        match ic.GetValue(loadingPopupProperty) with
-//                        | :? Popup as popup ->
-//                            popup.IsOpen <- false
-//                            ic.ClearValue(loadingPopupProperty)
-//                        | _ -> ()
-//                | _ -> ()
-//            ))
-//        )
+    static member SetShowLoadingOnGenerating (element: DependencyObject, value: bool) =
+        element.SetValue(ShowLoadingOnGeneratingProperty, value)
 
-//    let SetShowLoadingOnGenerating (element: DependencyObject) (value: bool) =
-//        element.SetValue(ShowLoadingOnGeneratingProperty, value)
-
-//    let GetShowLoadingOnGenerating (element: DependencyObject) =
-//        element.GetValue(ShowLoadingOnGeneratingProperty) :?> bool
+    static member GetShowLoadingOnGenerating (element: DependencyObject) =
+        element.GetValue(ShowLoadingOnGeneratingProperty) :?> bool

--- a/src/Other/Internals/ItemsControlLoadingBehavior.vb
+++ b/src/Other/Internals/ItemsControlLoadingBehavior.vb
@@ -1,0 +1,93 @@
+﻿Imports System.Windows
+Imports System.Windows.Controls
+Imports System.Windows.Controls.Primitives
+
+Namespace OpenSilver.Samples.Showcase
+    Public NotInheritable Class ItemsControlLoadingBehavior
+        Private Sub New()
+        End Sub
+
+        Public Shared ReadOnly ShowLoadingOnGeneratingProperty As DependencyProperty =
+            DependencyProperty.RegisterAttached(
+                "ShowLoadingOnGenerating",
+                GetType(Boolean),
+                GetType(ItemsControlLoadingBehavior),
+                New PropertyMetadata(False, AddressOf OnShowLoadingOnGeneratingChanged)
+            )
+
+        Public Shared Sub SetShowLoadingOnGenerating(element As DependencyObject, value As Boolean)
+            element.SetValue(ShowLoadingOnGeneratingProperty, value)
+        End Sub
+
+        Public Shared Function GetShowLoadingOnGenerating(element As DependencyObject) As Boolean
+            Return CBool(element.GetValue(ShowLoadingOnGeneratingProperty))
+        End Function
+
+        Private Shared ReadOnly StatusChangedHandlerProperty As DependencyProperty =
+            DependencyProperty.RegisterAttached(
+                "StatusChangedHandler",
+                GetType(EventHandler),
+                GetType(ItemsControlLoadingBehavior),
+                Nothing
+            )
+
+        Private Shared ReadOnly LoadingPopupProperty As DependencyProperty =
+            DependencyProperty.RegisterAttached(
+                "LoadingPopup",
+                GetType(Popup),
+                GetType(ItemsControlLoadingBehavior),
+                Nothing
+            )
+
+        Private Shared Sub OnShowLoadingOnGeneratingChanged(d As DependencyObject, e As DependencyPropertyChangedEventArgs)
+            Dim itemsControl = TryCast(d, ItemsControl)
+            If itemsControl Is Nothing Then Return
+
+            Dim enabled As Boolean = CBool(e.NewValue)
+            If enabled Then
+                Dim handler As EventHandler = Sub(s, args) OnStatusChanged(itemsControl)
+                itemsControl.SetValue(StatusChangedHandlerProperty, handler)
+                AddHandler itemsControl.ItemContainerGenerator.StatusChanged, handler
+            Else
+                Dim handler = TryCast(itemsControl.GetValue(StatusChangedHandlerProperty), EventHandler)
+                If handler IsNot Nothing Then
+                    RemoveHandler itemsControl.ItemContainerGenerator.StatusChanged, handler
+                    itemsControl.ClearValue(StatusChangedHandlerProperty)
+                End If
+
+                Dim existing = TryCast(itemsControl.GetValue(LoadingPopupProperty), Popup)
+                If existing IsNot Nothing Then
+                    existing.IsOpen = False
+                    itemsControl.ClearValue(LoadingPopupProperty)
+                End If
+            End If
+        End Sub
+
+        Private Shared Sub OnStatusChanged(itemsControl As ItemsControl)
+            Dim status = itemsControl.ItemContainerGenerator.Status
+
+            If status = GeneratorStatus.GeneratingContainers Then
+                Dim popup As New Popup With {
+                    .Child = New LoadingControl(),
+                    .Placement = PlacementMode.Absolute,
+                    .IsHitTestVisible = False,
+                    .IsOpen = False
+                }
+
+                ' Overlay the whole window
+                Dim host = TryCast(Application.Current.RootVisual, FrameworkElement)
+                popup.Width = host.ActualWidth
+                popup.Height = host.ActualHeight
+
+                itemsControl.SetValue(LoadingPopupProperty, popup)
+                popup.IsOpen = True
+            Else
+                Dim popup = TryCast(itemsControl.GetValue(LoadingPopupProperty), Popup)
+                If popup IsNot Nothing Then
+                    popup.IsOpen = False
+                    itemsControl.ClearValue(LoadingPopupProperty)
+                End If
+            End If
+        End Sub
+    End Class
+End Namespace

--- a/src/Samples/Charts/Charts.xaml
+++ b/src/Samples/Charts/Charts.xaml
@@ -14,8 +14,14 @@
                                                                     data binding.
             </TextBlock>
         </StackPanel>
-        
-        <controlskit:StaggeredPanel DesiredColumnWidth="700" ProgressiveRenderingChunkSize="2">
+
+        <ItemsControl x:Name="SamplesPanel" local:ItemsControlLoadingBehavior.ShowLoadingOnGenerating="True">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <controlskit:StaggeredPanel DesiredColumnWidth="700" ProgressiveRenderingChunkSize="2"/>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+
             <local:AreaSeries_Demo/>
             <local:BarSeries_Demo/>
             <local:BubbleSeries_Demo/>
@@ -24,6 +30,7 @@
             <local:PieSeries_Demo/>
             <local:ScatterSeries_Demo/>
             <local:Stacked100AreaSeries_Demo/>
-        </controlskit:StaggeredPanel>
+
+        </ItemsControl>
     </StackPanel>
 </Page>

--- a/src/Samples/Client_Server/Client_Server.xaml
+++ b/src/Samples/Client_Server/Client_Server.xaml
@@ -4,7 +4,7 @@
              xmlns:controlskit="clr-namespace:OpenSilver.ControlsKit;assembly=OpenSilver.ControlsKit.Controls"
              xmlns:local="clr-namespace:OpenSilver.Samples.Showcase"
              Style="{StaticResource Page_Style}">
-    
+
     <StackPanel>
         <StackPanel>
             <ContentControl Content="Client / Server" Style="{StaticResource PageTitle_Style}"/>
@@ -16,13 +16,20 @@
                                                                     cross-origin communication.
             </TextBlock>
         </StackPanel>
-        
-        <controlskit:StaggeredPanel DesiredColumnWidth="320" ProgressiveRenderingChunkSize="2">
+
+        <ItemsControl x:Name="SamplesPanel" local:ItemsControlLoadingBehavior.ShowLoadingOnGenerating="True">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <controlskit:StaggeredPanel DesiredColumnWidth="320" ProgressiveRenderingChunkSize="2"/>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+
             <local:WCF_SOAP_Demo HorizontalAlignment="Center"/>
             <local:REST_HttpClient_Demo x:Name="REST_WebClientDemo" HorizontalAlignment="Center"/>
             <local:WebSockets_Demo HorizontalAlignment="Center"/>
             <local:RIAServices_Demo HorizontalAlignment="Center"/>
             <local:JSONP_Demo HorizontalAlignment="Center"/>
-        </controlskit:StaggeredPanel>
+            
+        </ItemsControl>
     </StackPanel>
 </Page>

--- a/src/Samples/Interop_Samples/Interop_Samples.xaml
+++ b/src/Samples/Interop_Samples/Interop_Samples.xaml
@@ -18,13 +18,20 @@
             </TextBlock>
         </StackPanel>
 
-        <controlskit:StaggeredPanel DesiredColumnWidth="280" ProgressiveRenderingChunkSize="2">
+        <ItemsControl x:Name="SamplesPanel" local:ItemsControlLoadingBehavior.ShowLoadingOnGenerating="True">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <controlskit:StaggeredPanel DesiredColumnWidth="280" ProgressiveRenderingChunkSize="2"/>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            
             <local:ExecuteJavaScript_Demo HorizontalAlignment="Center"/>
             <local:Interop_HtmlPresenter_Demo HorizontalAlignment="Center"/>
             <local:WebView_Demo HorizontalAlignment="Center"/>
             <local:GetDiv_Demo HorizontalAlignment="Center"/>
             <local:MethodToUpdateDom_Demo HorizontalAlignment="Center"/>
             <local:PWA_Demo/>
-        </controlskit:StaggeredPanel>
+            
+        </ItemsControl>
     </StackPanel>
 </Page>

--- a/src/Samples/JS_Libs/JS_Libs.xaml
+++ b/src/Samples/JS_Libs/JS_Libs.xaml
@@ -17,11 +17,18 @@
             </TextBlock>
         </StackPanel>
 
-        <controlskit:StaggeredPanel DesiredColumnWidth="280" ProgressiveRenderingChunkSize="2">
+        <ItemsControl x:Name="SamplesPanel" local:ItemsControlLoadingBehavior.ShowLoadingOnGenerating="True">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <controlskit:StaggeredPanel DesiredColumnWidth="280" ProgressiveRenderingChunkSize="2"/>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+
             <local:JSZip_Demo/>
             <local:ColorPicker_Demo/>
             <local:MonacoEditor_Demo/>
             <local:ToastUiEditor_Demo/>
-        </controlskit:StaggeredPanel>
+            
+        </ItemsControl>
     </StackPanel>
 </Page>

--- a/src/Samples/Maui_Hybrid/Maui_Hybrid.xaml
+++ b/src/Samples/Maui_Hybrid/Maui_Hybrid.xaml
@@ -20,7 +20,13 @@
             </TextBlock>
         </StackPanel>
 
-        <controlskit:StaggeredPanel ProgressiveRenderingChunkSize="2">
+        <ItemsControl x:Name="SamplesPanel" local:ItemsControlLoadingBehavior.ShowLoadingOnGenerating="True">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <controlskit:StaggeredPanel ProgressiveRenderingChunkSize="2"/>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            
             <local:Geolocation HorizontalAlignment="Center"/>
             <local:Flashlight_Demo HorizontalAlignment="Center"/>
             <local:Vibration_Demo HorizontalAlignment="Center"/>
@@ -33,7 +39,8 @@
             <local:Connectivity_Demo HorizontalAlignment="Center"/>
             <local:OpenMapApp_Demo HorizontalAlignment="Center"/>
             <local:Camera_Demo HorizontalAlignment="Center"/>
-        </controlskit:StaggeredPanel>
+
+        </ItemsControl>
     </StackPanel>
 
 </Page>

--- a/src/Samples/Net_Framework/Net_Framework.xaml
+++ b/src/Samples/Net_Framework/Net_Framework.xaml
@@ -18,8 +18,14 @@
                                                                     you can publish to native too.
             </TextBlock>
         </StackPanel>
-        
-        <controlskit:StaggeredPanel DesiredColumnWidth="280" ProgressiveRenderingChunkSize="2">
+
+        <ItemsControl x:Name="SamplesPanel" local:ItemsControlLoadingBehavior.ShowLoadingOnGenerating="True">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <controlskit:StaggeredPanel DesiredColumnWidth="280" ProgressiveRenderingChunkSize="2"/>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+
             <local:DispatcherTimer_Demo HorizontalAlignment="Center"/>
             <local:File_Open_Demo x:Name="File_OpenDemo" HorizontalAlignment="Center"/>
             <local:OpenFileDialog_Demo HorizontalAlignment="Center"/>
@@ -45,6 +51,7 @@
             <local:Clipboard_SetText_Demo HorizontalAlignment="Center"/>
             <local:FullScreen_Demo x:Name="FullScreenDemo" HorizontalAlignment="Center"/>
             <local:MVVM_Demo/>
-        </controlskit:StaggeredPanel>
+
+        </ItemsControl>
     </StackPanel>
 </Page>

--- a/src/Samples/Performance/Performance.xaml
+++ b/src/Samples/Performance/Performance.xaml
@@ -20,11 +20,18 @@
             </TextBlock>
         </StackPanel>
 
-        <controlskit:StaggeredPanel ProgressiveRenderingChunkSize="2" DesiredColumnWidth="330">
+        <ItemsControl x:Name="SamplesPanel" local:ItemsControlLoadingBehavior.ShowLoadingOnGenerating="True">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <controlskit:StaggeredPanel DesiredColumnWidth="330" ProgressiveRenderingChunkSize="2"/>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            
             <local:Virtualization_Demo/>
             <local:ProgressiveLoading_Demo/>
             <local:AOT_Demo/>
             <local:HtmlCanvas_Demo HorizontalAlignment="Center"/>
-        </controlskit:StaggeredPanel>
+
+        </ItemsControl>
     </StackPanel>
 </Page>

--- a/src/Samples/SearchPage.xaml
+++ b/src/Samples/SearchPage.xaml
@@ -15,8 +15,14 @@
                 <Path Stroke="White" Data="M 17 17 A 1 1 0 0 0 -17 -17 A 1 1 0 0 0 17 17 L 52 54" StrokeThickness="2" Stretch="Uniform"/>
             </Button>
         </StackPanel>-->
-        <controlskit:StaggeredPanel Grid.Row="1" ProgressiveRenderingChunkSize="2" x:Name="SamplesContainer">
 
-        </controlskit:StaggeredPanel>
+        <ItemsControl x:Name="SamplesPanel" local:ItemsControlLoadingBehavior.ShowLoadingOnGenerating="True">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <controlskit:StaggeredPanel ProgressiveRenderingChunkSize="2"/>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+        </ItemsControl>
+        
     </StackPanel>
 </Page>

--- a/src/Samples/SearchPage.xaml.cs
+++ b/src/Samples/SearchPage.xaml.cs
@@ -56,7 +56,7 @@ namespace OpenSilver.Samples.Showcase
         {
             //todo: if multiple searches one after the other, increase efficiency by only looking at the changes between the current search and the previous search
             //for now, we just clear everything.
-            SamplesContainer.Children.Clear();
+            SamplesPanel.Items.Clear();
 
             if (!string.IsNullOrWhiteSpace(searchText))
             {
@@ -70,7 +70,7 @@ namespace OpenSilver.Samples.Showcase
 
                         if (controlInstance is UIElement uiElement)
                         {
-                            SamplesContainer.Children.Add(uiElement);
+                            SamplesPanel.Items.Add(uiElement);
                         }
                     }
                 }

--- a/src/Samples/SearchPage.xaml.fs
+++ b/src/Samples/SearchPage.xaml.fs
@@ -48,7 +48,7 @@ type SearchPage() as this =
     //    this.NavigationService.Navigate(Uri($"/Search/{searchText}", UriKind.Relative)) |> ignore
 
     member internal this.PerformSearch(searchText: string) =
-        this.SamplesContainer.Children.Clear()
+        this.SamplesPanel.Items.Clear()
 
         if not (String.IsNullOrWhiteSpace searchText) then
             let searchResult = ControlSearch.Search(searchText)
@@ -59,5 +59,5 @@ type SearchPage() as this =
                     let controlInstance = Activator.CreateInstance(sampleType)
                     match controlInstance with
                     | :? UIElement as uiElement ->
-                        this.SamplesContainer.Children.Add(uiElement)
+                        this.SamplesPanel.Items.Add(uiElement)
                     | _ -> ()

--- a/src/Samples/SearchPage.xaml.vb
+++ b/src/Samples/SearchPage.xaml.vb
@@ -1,6 +1,5 @@
 ﻿Imports System.Windows
 Imports System.Windows.Controls
-Imports System.Windows.Input
 Imports System.Windows.Navigation
 Imports OpenSilver.Samples.Showcase.Search
 
@@ -47,7 +46,7 @@ Namespace OpenSilver.Samples.Showcase
         Friend Sub PerformSearch(searchText As String)
             'todo: if multiple searches one after the other, increase efficiency by only looking at the changes between the current search and the previous search
             'for now, we just clear everything.
-            SamplesContainer.Children.Clear()
+            SamplesPanel.Items.Clear()
 
             If Not String.IsNullOrWhiteSpace(searchText) Then
                 Dim searchResult = ControlSearch.Search(searchText)
@@ -57,7 +56,7 @@ Namespace OpenSilver.Samples.Showcase
                         Dim controlInstance As Object = Activator.CreateInstance(sampleType)
 
                         If TypeOf controlInstance Is UIElement Then
-                            SamplesContainer.Children.Add(CType(controlInstance, UIElement))
+                            SamplesPanel.Items.Add(CType(controlInstance, UIElement))
                         End If
                     End If
                 Next

--- a/src/Samples/XAML_Controls/Xaml_Controls.xaml
+++ b/src/Samples/XAML_Controls/Xaml_Controls.xaml
@@ -16,7 +16,13 @@
             </TextBlock>
         </StackPanel>
 
-        <controlskit:StaggeredPanel Name="SamplesPanel" ProgressiveRenderingChunkSize="2">
+        <ItemsControl x:Name="SamplesPanel" local:ItemsControlLoadingBehavior.ShowLoadingOnGenerating="True">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <controlskit:StaggeredPanel ProgressiveRenderingChunkSize="2"/>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            
             <local:TreeView_Demo HorizontalAlignment="Center"/>
             <local:TreeMap_Demo/>
             <local:InkPresenter_Demo/>
@@ -60,6 +66,7 @@
             <local:GlobalCalendar_Demo/>
             <local:Rating_Demo/>
             <local:ContextMenu_MenuItem_Demo x:Name="MenuItemDemo" HorizontalAlignment="Center"/>
-        </controlskit:StaggeredPanel>
+
+        </ItemsControl>
     </StackPanel>
 </Page>

--- a/src/Samples/XAML_Controls/Xaml_Controls.xaml.cs
+++ b/src/Samples/XAML_Controls/Xaml_Controls.xaml.cs
@@ -1,4 +1,10 @@
-﻿using System.Windows.Controls;
+﻿using System;
+using System.Net;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Media;
+using System.Windows.Media.Effects;
 
 namespace OpenSilver.Samples.Showcase;
 
@@ -8,7 +14,7 @@ public partial class Xaml_Controls : Page
     {
         InitializeComponent();
 
-        var dataGridDemoIndex = SamplesPanel.Children.IndexOf(DataGridDemo);
-        SamplesPanel.Children.Insert(dataGridDemoIndex, new DataGridGrouping());
+        var dataGridDemoIndex = SamplesPanel.Items.IndexOf(DataGridDemo);
+        SamplesPanel.Items.Insert(dataGridDemoIndex, new DataGridGrouping());
     }
 }

--- a/src/Samples/XAML_Features/XAML_Features.xaml
+++ b/src/Samples/XAML_Features/XAML_Features.xaml
@@ -16,8 +16,14 @@
                                                                     for integrated design tools.
             </TextBlock>
         </StackPanel>
+        
+        <ItemsControl x:Name="SamplesPanel" local:ItemsControlLoadingBehavior.ShowLoadingOnGenerating="True">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <controlskit:StaggeredPanel DesiredColumnWidth="280" ProgressiveRenderingChunkSize="2"/>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
 
-        <controlskit:StaggeredPanel DesiredColumnWidth="280" ProgressiveRenderingChunkSize="2">
             <local:RenderTransforms_Demo HorizontalAlignment="Center"/>
             <local:Drag_And_Drop_Demo HorizontalAlignment="Center"/>
             <local:Binding1_Demo x:Name="Binding1Demo" HorizontalAlignment="Center"/>
@@ -52,6 +58,7 @@
             <local:Clipping_Demo/>
             <local:Cursor_Demo/>
             <local:FlowDirection_Demo/>
-        </controlskit:StaggeredPanel>
+            
+        </ItemsControl>
     </StackPanel>
 </Page>

--- a/src/Samples/XAML_Layout/Xaml_Layout.xaml
+++ b/src/Samples/XAML_Layout/Xaml_Layout.xaml
@@ -14,7 +14,13 @@
             </TextBlock>
         </StackPanel>
 
-        <controlskit:StaggeredPanel Name="SamplesPanel" ProgressiveRenderingChunkSize="2">
+        <ItemsControl x:Name="SamplesPanel" local:ItemsControlLoadingBehavior.ShowLoadingOnGenerating="True">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <controlskit:StaggeredPanel ProgressiveRenderingChunkSize="2"/>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+
             <local:Grid_Demo HorizontalAlignment="Center"/>
             <local:UniformGrid_Demo/>
             <local:StackPanel_Demo HorizontalAlignment="Center"/>
@@ -36,6 +42,7 @@
             <local:Viewbox_Demo HorizontalAlignment="Center"/>
             <local:TransitioningContentControl_Demo/>
             <local:LayoutTransformer_Demo/>
-        </controlskit:StaggeredPanel>
+
+        </ItemsControl>
     </StackPanel>
 </Page>


### PR DESCRIPTION
Some pages like "Controls" may take up to 6 seconds to fully load. While a page is loading, scrolling is very slow. The problem is that users don't necessarily know that the page is still loading, so they might mistakenly think that scrolling is always slow in OpenSilver apps, which is not the case.

To address this problem, this PR will make it so that, **if a page takes more than 1 second to load**, we display a "Loading, please wait..." message. This will set the expectations right: the user will know that scrolling is slow because we are loading something, not because of scrolling issues.

Screenshot:

![image](https://github.com/user-attachments/assets/7b7ba722-bbe4-45ce-b9be-0ae8c1aefbb5)

