### PR TITLE
Add setting for EasingMode in 'OpenSilver.Animations' and make the initial animation less overwwhelming.

### DIFF
--- a/Libraries/OpenSilver.Animations/AnimationTypes/Fade.cs
+++ b/Libraries/OpenSilver.Animations/AnimationTypes/Fade.cs
@@ -34,6 +34,11 @@ namespace OpenSilver.Animations
         /// </summary>
         public int Duration { get; set; } = 250;
 
+        /// <summary>
+        /// Easing function to be used for the animation.
+        /// </summary>
+        public EasingMode EasingMode { get; set; } = EasingMode.EaseOut;
+
         public override object ProvideValue(IServiceProvider serviceProvider)
         {
             return this;
@@ -45,6 +50,7 @@ namespace OpenSilver.Animations
                 elementToAnimate: elementToAnimate,
                 duration: Duration,
                 delay: Delay,
+                easingMode: EasingMode,
                 includeFade: true);
         }
     }

--- a/Libraries/OpenSilver.Animations/AnimationTypes/FadeAndScale.cs
+++ b/Libraries/OpenSilver.Animations/AnimationTypes/FadeAndScale.cs
@@ -37,6 +37,11 @@ namespace OpenSilver.Animations
         public int Duration { get; set; } = 250;
 
         /// <summary>
+        /// Easing function to be used for the animation.
+        /// </summary>
+        public EasingMode EasingMode { get; set; } = EasingMode.EaseOut;
+
+        /// <summary>
         /// Determines the intensity of the elastic effect.
         /// Higher values result in greater overshoot and oscillation,
         /// simulating a more dynamic and spring-like motion.
@@ -55,6 +60,7 @@ namespace OpenSilver.Animations
                 elementToAnimate: elementToAnimate,
                 duration: Duration,
                 delay: Delay,
+                easingMode: EasingMode,
                 bounciness: Bounciness,
                 includeFade: true,
                 includeScale: true);

--- a/Libraries/OpenSilver.Animations/AnimationTypes/FadeAndSlide.cs
+++ b/Libraries/OpenSilver.Animations/AnimationTypes/FadeAndSlide.cs
@@ -35,6 +35,11 @@ namespace OpenSilver.Animations
         public int Duration { get; set; } = 250;
 
         /// <summary>
+        /// Easing function to be used for the animation.
+        /// </summary>
+        public EasingMode EasingMode { get; set; } = EasingMode.EaseOut;
+
+        /// <summary>
         /// Direction of the slide animation
         /// </summary>
         public Direction Direction { get; set; } = Direction.DownToUp;
@@ -58,6 +63,7 @@ namespace OpenSilver.Animations
                 elementToAnimate: elementToAnimate,
                 duration: Duration,
                 delay: Delay,
+                easingMode: EasingMode,
                 direction: Direction,
                 bounciness: Bounciness,
                 includeFade: true,

--- a/Libraries/OpenSilver.Animations/IAnimationType.cs
+++ b/Libraries/OpenSilver.Animations/IAnimationType.cs
@@ -15,6 +15,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text;
 using System.Windows;
+using System.Windows.Media.Animation;
 
 namespace OpenSilver.Animations
 {
@@ -32,5 +33,10 @@ namespace OpenSilver.Animations
         /// Duration in milliseconds
         /// </summary>
         int Duration { get; set; }
+
+        /// <summary>
+        /// Easing function to be used for the animation.
+        /// </summary>
+        EasingMode EasingMode { get; set; }
     }
 }

--- a/Libraries/OpenSilver.Animations/Internal/StoryboardsHelper.cs
+++ b/Libraries/OpenSilver.Animations/Internal/StoryboardsHelper.cs
@@ -13,9 +13,11 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Windows.Media.Animation;
-using System.Windows.Media;
+using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
 using System.Windows.Threading;
 
 namespace OpenSilver.Animations.Internal
@@ -25,6 +27,7 @@ namespace OpenSilver.Animations.Internal
         public static void AnimateElement(FrameworkElement elementToAnimate,
             int duration,
             int delay,
+            EasingMode easingMode = EasingMode.EaseOut,
             double bounciness = 0.0,
             Direction direction = Direction.DownToUp,
             bool includeFade = false,
@@ -47,6 +50,7 @@ namespace OpenSilver.Animations.Internal
                             elementToAnimate: elementToAnimate,
                             duration: duration,
                             delay: delay,
+                            easingMode: easingMode,
                             bounciness: bounciness,
                             direction: direction,
                             includeFade: includeFade,
@@ -58,6 +62,7 @@ namespace OpenSilver.Animations.Internal
         public static void ApplyAnimateElement(FrameworkElement elementToAnimate,
             int duration,
             int delay,
+            EasingMode easingMode = EasingMode.EaseOut,
             double bounciness = 0.0,
             Direction direction = Direction.DownToUp,
             bool includeFade = false,
@@ -93,7 +98,7 @@ namespace OpenSilver.Animations.Internal
                     Duration = TimeSpan.FromMilliseconds(duration),
                     BeginTime = TimeSpan.FromMilliseconds(delay),
                     FillBehavior = FillBehavior.HoldEnd,
-                    EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut }
+                    EasingFunction = new CubicEase { EasingMode = easingMode }
                 };
                 Storyboard.SetTarget(opacityAnim, elementToAnimate);
                 Storyboard.SetTargetProperty(opacityAnim, new PropertyPath(UIElement.OpacityProperty));
@@ -127,8 +132,8 @@ namespace OpenSilver.Animations.Internal
                     FillBehavior = FillBehavior.HoldEnd,
                     EasingFunction =
                         bounciness > 0.0 ?
-                        new BackEase { Amplitude = bounciness, EasingMode = EasingMode.EaseOut } :
-                        new CubicEase { EasingMode = EasingMode.EaseOut }
+                        new BackEase { Amplitude = bounciness, EasingMode = easingMode } :
+                        new CubicEase { EasingMode = easingMode }
                 };
                 Storyboard.SetTarget(scaleXAnim, elementToAnimate);
                 Storyboard.SetTargetProperty(scaleXAnim, new PropertyPath("RenderTransform.ScaleX"));
@@ -144,8 +149,8 @@ namespace OpenSilver.Animations.Internal
                     FillBehavior = FillBehavior.HoldEnd,
                     EasingFunction =
                         bounciness > 0.0 ?
-                        new BackEase { Amplitude = bounciness, EasingMode = EasingMode.EaseOut } :
-                        new CubicEase { EasingMode = EasingMode.EaseOut }
+                        new BackEase { Amplitude = bounciness, EasingMode = easingMode } :
+                        new CubicEase { EasingMode = easingMode }
                 };
                 Storyboard.SetTarget(scaleYAnim, elementToAnimate);
                 Storyboard.SetTargetProperty(scaleYAnim, new PropertyPath("RenderTransform.ScaleY"));
@@ -180,8 +185,8 @@ namespace OpenSilver.Animations.Internal
                             FillBehavior = FillBehavior.HoldEnd,
                             EasingFunction =
                                 bounciness > 0.0 ?
-                                new BackEase { Amplitude = bounciness, EasingMode = EasingMode.EaseOut } :
-                                new CubicEase { EasingMode = EasingMode.EaseOut }
+                                new BackEase { Amplitude = bounciness, EasingMode = easingMode } :
+                                new CubicEase { EasingMode = easingMode }
                         };
                         Storyboard.SetTarget(translateXAnim, elementToAnimate);
                         Storyboard.SetTargetProperty(translateXAnim, new PropertyPath("RenderTransform.X"));
@@ -205,8 +210,8 @@ namespace OpenSilver.Animations.Internal
                             FillBehavior = FillBehavior.HoldEnd,
                             EasingFunction =
                                 bounciness > 0.0 ?
-                                new BackEase { Amplitude = bounciness, EasingMode = EasingMode.EaseOut } :
-                                new CubicEase { EasingMode = EasingMode.EaseOut }
+                                new BackEase { Amplitude = bounciness, EasingMode = easingMode } :
+                                new CubicEase { EasingMode = easingMode }
                         };
                         Storyboard.SetTarget(translateYAnim, elementToAnimate);
                         Storyboard.SetTargetProperty(translateYAnim, new PropertyPath("RenderTransform.Y"));
@@ -240,8 +245,8 @@ namespace OpenSilver.Animations.Internal
                     FillBehavior = FillBehavior.HoldEnd,
                     EasingFunction =
                         applyBouncinessOnWidthAnimation ?
-                        new BackEase { Amplitude = bounciness, EasingMode = EasingMode.EaseOut } :
-                        new CubicEase { EasingMode = EasingMode.EaseOut }
+                        new BackEase { Amplitude = bounciness, EasingMode = easingMode } :
+                        new CubicEase { EasingMode = easingMode }
                 };
                 Storyboard.SetTarget(widthAnim, elementToAnimate);
                 Storyboard.SetTargetProperty(widthAnim, new PropertyPath("WidthAsPercentageOfChild"));
@@ -257,8 +262,8 @@ namespace OpenSilver.Animations.Internal
                     FillBehavior = FillBehavior.HoldEnd,
                     EasingFunction =
                         applyBouncinessOnHeight ?
-                        new BackEase { Amplitude = bounciness, EasingMode = EasingMode.EaseOut } :
-                        new CubicEase { EasingMode = EasingMode.EaseOut }
+                        new BackEase { Amplitude = bounciness, EasingMode = easingMode } :
+                        new CubicEase { EasingMode = easingMode }
                 };
                 Storyboard.SetTarget(heightAnim, elementToAnimate);
                 Storyboard.SetTargetProperty(heightAnim, new PropertyPath("HeightAsPercentageOfChild"));

--- a/Libraries/OpenSilver.Animations/PropertyAnimator.cs
+++ b/Libraries/OpenSilver.Animations/PropertyAnimator.cs
@@ -86,6 +86,11 @@ namespace OpenSilver.Animations
         public TimeSpan Duration { get; set; }
 
         /// <summary>
+        /// Gets or sets the delay of the animation.
+        /// </summary>
+        public TimeSpan? BeginTime { get; set; }
+
+        /// <summary>
         /// Gets or sets the easing function for the animation.
         /// </summary>
         public IEasingFunction EasingFunction { get; set; }
@@ -215,8 +220,10 @@ namespace OpenSilver.Animations
             {
                 From = 0.0,
                 To = 1.0,
+                BeginTime = BeginTime,
                 Duration = new Duration(Duration),
-                EasingFunction = EasingFunction
+                EasingFunction = EasingFunction,
+                FillBehavior = FillBehavior.HoldEnd
             };
 
             // Set target to the proxy object

--- a/src/MainPage.xaml
+++ b/src/MainPage.xaml
@@ -126,7 +126,7 @@ mc:Ignorable="d"
             </Grid>
 
             <!-- Menu -->
-            <animations:AnimatedContentControl x:Name="MenuContainer" Canvas.ZIndex="3" animations:Animation.OnAppear="{animations:FadeAndSlide Delay=2000, Direction=LeftToRight, Duration=500, Bounciness=0.3}" HorizontalAlignment="Left">
+            <animations:AnimatedContentControl x:Name="MenuContainer" Canvas.ZIndex="3" animations:Animation.OnAppear="{animations:Fade Delay=4000, Duration=2000, EasingMode=EaseInOut}" HorizontalAlignment="Left">
                 <Border x:Name="MenuBorder" Canvas.ZIndex="1" Width="240" Background="{DynamicResource Theme_BackgroundBrush}">
                     <Border.Effect>
                         <DropShadowEffect ShadowDepth="3" Color="Black" BlurRadius="14" Opacity="0.15" />
@@ -134,7 +134,7 @@ mc:Ignorable="d"
                     <Border.RenderTransform>
                         <TranslateTransform/>
                     </Border.RenderTransform>
-                    <DockPanel LastChildFill="True" animations:Animation.OnAppear="{animations:FadeAndSlide Delay=2250, Direction=LeftToRight, Duration=500, Bounciness=0.3}">
+                    <DockPanel LastChildFill="True">
                         <Border DockPanel.Dock="Bottom" Margin="0,10,0,20" Padding="3" CornerRadius="7" HorizontalAlignment="Center" Background="{DynamicResource Theme_BackgroundBrush}">
                             <StackPanel Orientation="Horizontal">
                                 <RadioButton x:Name="LightThemeRadioButton" IsChecked="True" Checked="ThemeToggle_RadioButton_Checked" animations:SpringEffect.IsEnabled="True">

--- a/src/Samples/Welcome.xaml
+++ b/src/Samples/Welcome.xaml
@@ -15,12 +15,12 @@
             <ContentControl animations:Animation.OnAppear="{animations:FadeAndScale Delay=500, Duration=1000, Bounciness=1}" HorizontalAlignment="Center" Background="{DynamicResource Theme_ControlBackgroundBrush}" Style="{StaticResource WelcomeTitle_Style}">
                 <StackPanel>
                     <TextBlock Text="Welcome" HorizontalAlignment="Center" FontSize="80"/>
-                    <animations:AnimatedContentControl animations:Animation.OnAppear="{animations:FadeAndScale Delay=1500, Bounciness=0.3}">
+                    <animations:AnimatedContentControl animations:Animation.OnAppear="{animations:FadeAndScale Delay=1500, EasingMode=EaseInOut}">
                         <TextBlock Text="TO THE OPENSILVER FEATURES SHOWCASE!" Margin="0,0,0,12" FontSize="12" Opacity="0.7" Foreground="{DynamicResource Theme_TextBrush}" FontWeight="Bold" CharacterSpacing="100" HorizontalAlignment="Center"/>
                     </animations:AnimatedContentControl>
                 </StackPanel>
             </ContentControl>
-            <animations:AnimatedContentControl Opacity="0" animations:Animation.OnAppear="{animations:FadeAndSlide Delay=2700, Duration=500, Bounciness=0.1, Direction=DownToUp}">
+            <animations:AnimatedContentControl Opacity="0" animations:Animation.OnAppear="{animations:FadeAndScale Delay=2700, Duration=1000, EasingMode=EaseInOut}">
                 <Border Background="{DynamicResource Theme_ControlBackgroundBrush}" CornerRadius="20" MaxWidth="800" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="40,0,40,20">
                     <Border.Effect>
                         <DropShadowEffect ShadowDepth="3" Color="Black" BlurRadius="20" Opacity="0.2" />


### PR DESCRIPTION
It's now possible to specify an easing mode in animations, like this:

<Border animations:Animation.OnAppear="{animations:FadeAndScale Delay=1500, Duration=500, EasingMode=EaseInOut}" />

Also made the initial animation less overwhelming.