### PR TITLE
Staggered layout fixes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <OpenSilverVersion Condition=" '$(OpenSilverVersion)' == '' ">3.3.0-preview-2025-05-20-160000-27ff988e</OpenSilverVersion>
 	<OpenSilverModernThemeVersion Condition=" '$(OpenSilverModernThemeVersion)' == '' ">3.3.0-preview-2025-05-13-080949-c4fa6b18</OpenSilverModernThemeVersion>
-    <OpenSilverControlsKitVersion Condition=" '$(OpenSilverControlsKitVersion)' == '' ">3.3.0-preview-2025-05-23-112427-1a5fbe5</OpenSilverControlsKitVersion>
+    <OpenSilverControlsKitVersion Condition=" '$(OpenSilverControlsKitVersion)' == '' ">3.3.0-preview-2025-05-29-144830-abc7626</OpenSilverControlsKitVersion>
   </PropertyGroup>
 </Project>

--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -16,6 +16,9 @@ namespace OpenSilver.Samples.Showcase
         {
             await FontFamily.LoadFontAsync("ms-appx:///OpenSilver.Samples.Showcase/Other/Inter_VariableFont_slnt_wght.ttf");
 
+            Features.DOM.AssignClass = true;
+            await Interop.LoadCssFile("ms-appx:///OpenSilver.Samples.Showcase/Other/CSS/app-styles.css");
+
             var mainPage = new MainPage();
             Window.Current.Content = mainPage;
         }

--- a/src/App.xaml.vb
+++ b/src/App.xaml.vb
@@ -13,6 +13,9 @@ Namespace OpenSilver.Samples.Showcase
         Private Async Sub OnAppStartup(sender As Object, e As StartupEventArgs)
             Await FontFamily.LoadFontAsync("ms-appx:///OpenSilver.Samples.Showcase/Other/Inter_VariableFont_slnt_wght.ttf")
 
+            Features.DOM.AssignClass = True
+            Await Interop.LoadCssFile("ms-appx:///OpenSilver.Samples.Showcase/Other/CSS/app-styles.css")
+
             Dim mainPage As New MainPage()
             Window.Current.Content = mainPage
         End Sub

--- a/src/OpenSilver.Samples.Showcase.csproj
+++ b/src/OpenSilver.Samples.Showcase.csproj
@@ -372,6 +372,7 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Content>
+    <Content Include="Other\CSS\app-styles.css" />
     <Content Include="Other\embed.js">
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>

--- a/src/OpenSilver.Samples.Showcase.fsproj
+++ b/src/OpenSilver.Samples.Showcase.fsproj
@@ -37,6 +37,7 @@
 		<Compile Include="Samples\Net_Framework\MVVM\Movie.fs" />
 		<Compile Include="Samples\Net_Framework\MVVM\MoviesViewModel.fs" />
 		<Compile Include="Samples\XAML_Features\Command\CommandDemoViewModel.fs" />
+		<Content Include="Other\CSS\app-styles.css" />
 		<Content Include="Other\embed.js">
 			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>
 			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>

--- a/src/OpenSilver.Samples.Showcase.vbproj
+++ b/src/OpenSilver.Samples.Showcase.vbproj
@@ -362,6 +362,7 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Content>
+    <Content Include="Other\CSS\app-styles.css" />
     <Content Include="Other\embed.js">
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>

--- a/src/Other/CSS/app-styles.css
+++ b/src/Other/CSS/app-styles.css
@@ -1,0 +1,3 @@
+﻿.OpenSilver\.ControlsKit\.StaggeredPanel > div > .System\.Windows\.Controls\.ContentControl[style*='clip'] {
+    clip: revert !important;
+}

--- a/src/Other/Styles.xaml
+++ b/src/Other/Styles.xaml
@@ -85,11 +85,11 @@
     <Style x:Key="HeaderControl_Style" TargetType="ContentControl">
         <Style.Setters>
             <Setter Property="FontSize" Value="22"/>
+            <Setter Property="Margin" Value="-24,-16,-24,16" />
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="ContentControl">
                         <Border Background="{TemplateBinding Foreground}"
-                                Margin="-24,-16,-24,16"
                                 Padding="14,8,16,8"
                                 CornerRadius="32"
                                 HorizontalAlignment="Left"

--- a/src/Samples/Charts/Charts.xaml
+++ b/src/Samples/Charts/Charts.xaml
@@ -23,15 +23,14 @@
                 </ItemsPanelTemplate>
             </ItemsControl.ItemsPanel>
 
-            <local:AreaSeries_Demo/>
-            <local:BarSeries_Demo/>
-            <local:BubbleSeries_Demo/>
-            <local:ColumnSeries_Demo/>
-            <local:LineSeries_Demo/>
-            <local:PieSeries_Demo/>
-            <local:ScatterSeries_Demo/>
-            <local:Stacked100AreaSeries_Demo/>
-
+            <local:AreaSeries_Demo HorizontalAlignment="Center"/>
+            <local:BarSeries_Demo HorizontalAlignment="Center"/>
+            <local:BubbleSeries_Demo HorizontalAlignment="Center"/>
+            <local:ColumnSeries_Demo HorizontalAlignment="Center"/>
+            <local:LineSeries_Demo HorizontalAlignment="Center"/>
+            <local:PieSeries_Demo HorizontalAlignment="Center"/>
+            <local:ScatterSeries_Demo HorizontalAlignment="Center"/>
+            <local:Stacked100AreaSeries_Demo HorizontalAlignment="Center"/>
         </ItemsControl>
     </StackPanel>
 </Page>

--- a/src/Samples/Interop_Samples/Interop_Samples.xaml
+++ b/src/Samples/Interop_Samples/Interop_Samples.xaml
@@ -31,8 +31,7 @@
             <local:WebView_Demo HorizontalAlignment="Center"/>
             <local:GetDiv_Demo HorizontalAlignment="Center"/>
             <local:MethodToUpdateDom_Demo HorizontalAlignment="Center"/>
-            <local:PWA_Demo/>
-            
+            <local:PWA_Demo HorizontalAlignment="Center"/>            
         </ItemsControl>
     </StackPanel>
 </Page>

--- a/src/Samples/JS_Libs/JS_Libs.xaml
+++ b/src/Samples/JS_Libs/JS_Libs.xaml
@@ -21,7 +21,7 @@
         <ItemsControl x:Name="SamplesPanel" local:ItemsControlLoadingBehavior.ShowLoadingOnGenerating="True">
             <ItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>
-                    <controlskit:StaggeredPanel DesiredColumnWidth="280" ProgressiveRenderingChunkSize="2"/>
+                    <controlskit:StaggeredPanel DesiredColumnWidth="330" ProgressiveRenderingChunkSize="2"/>
                 </ItemsPanelTemplate>
             </ItemsControl.ItemsPanel>
 

--- a/src/Samples/JS_Libs/JS_Libs.xaml
+++ b/src/Samples/JS_Libs/JS_Libs.xaml
@@ -25,11 +25,10 @@
                 </ItemsPanelTemplate>
             </ItemsControl.ItemsPanel>
 
-            <local:JSZip_Demo/>
-            <local:ColorPicker_Demo/>
-            <local:MonacoEditor_Demo/>
-            <local:ToastUiEditor_Demo/>
-            
+            <local:JSZip_Demo HorizontalAlignment="Center"/>
+            <local:ColorPicker_Demo HorizontalAlignment="Center"/>
+            <local:MonacoEditor_Demo HorizontalAlignment="Center"/>
+            <local:ToastUiEditor_Demo HorizontalAlignment="Center"/>            
         </ItemsControl>
     </StackPanel>
 </Page>

--- a/src/Samples/Net_Framework/Net_Framework.xaml
+++ b/src/Samples/Net_Framework/Net_Framework.xaml
@@ -30,13 +30,13 @@
             <local:DispatcherTimer_Demo HorizontalAlignment="Center"/>
             <local:File_Open_Demo x:Name="File_OpenDemo" HorizontalAlignment="Center"/>
             <local:OpenFileDialog_Demo HorizontalAlignment="Center"/>
-            <local:WriteableBitmap_Demo/>
+            <local:WriteableBitmap_Demo HorizontalAlignment="Center"/>
             <local:File_Save_Demo x:Name="File_SaveDemo" HorizontalAlignment="Center"/>
             <local:Printing_Demo HorizontalAlignment="Center"/>
             <local:Zip_Demo x:Name="ZipDemo" HorizontalAlignment="Center"/>
             <local:HtmlPage_Demo HorizontalAlignment="Center"/>
-            <local:UnhandledException_Demo/>
-            <local:InitParams_Demo/>
+            <local:UnhandledException_Demo HorizontalAlignment="Center"/>
+            <local:InitParams_Demo HorizontalAlignment="Center"/>
             <local:Keyboard_Demo HorizontalAlignment="Center"/>
             <local:IsolatedStorageFile_Demo HorizontalAlignment="Center"/>
             <local:IsolatedStorageSettings_Demo HorizontalAlignment="Center"/>
@@ -47,12 +47,11 @@
             <local:DataContractSerializer_Demo HorizontalAlignment="Center" VerticalAlignment="Top"/>
             <local:Console_Demo x:Name="ConsoleDemo" HorizontalAlignment="Center"/>
             <local:GetResourceStream_Demo x:Name="GetRessourceStreamDemo" HorizontalAlignment="Center"/>
-            <local:RESX_Demo/>
-            <local:Localization_Demo/>
+            <local:RESX_Demo HorizontalAlignment="Center"/>
+            <local:Localization_Demo HorizontalAlignment="Center"/>
             <local:Clipboard_SetText_Demo HorizontalAlignment="Center"/>
             <local:FullScreen_Demo x:Name="FullScreenDemo" HorizontalAlignment="Center"/>
-            <local:MVVM_Demo/>
-
+            <local:MVVM_Demo HorizontalAlignment="Center"/>
         </ItemsControl>
     </StackPanel>
 </Page>

--- a/src/Samples/Performance/Performance.xaml
+++ b/src/Samples/Performance/Performance.xaml
@@ -28,11 +28,10 @@
                 </ItemsPanelTemplate>
             </ItemsControl.ItemsPanel>
             
-            <local:Virtualization_Demo/>
-            <local:ProgressiveLoading_Demo/>
-            <local:AOT_Demo/>
+            <local:Virtualization_Demo HorizontalAlignment="Center"/>
+            <local:ProgressiveLoading_Demo HorizontalAlignment="Center"/>
+            <local:AOT_Demo HorizontalAlignment="Center"/>
             <!--<local:HtmlCanvas_Demo HorizontalAlignment="Center"/>-->
-
         </ItemsControl>
     </StackPanel>
 </Page>

--- a/src/Samples/XAML_Controls/Xaml_Controls.xaml
+++ b/src/Samples/XAML_Controls/Xaml_Controls.xaml
@@ -20,7 +20,7 @@
         <ItemsControl x:Name="SamplesPanel" local:ItemsControlLoadingBehavior.ShowLoadingOnGenerating="True">
             <ItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>
-                    <controlskit:StaggeredPanel ProgressiveRenderingChunkSize="2"/>
+                    <controlskit:StaggeredPanel ProgressiveRenderingChunkSize="2" DesiredColumnWidth="270"/>
                 </ItemsPanelTemplate>
             </ItemsControl.ItemsPanel>
             

--- a/src/Samples/XAML_Controls/Xaml_Controls.xaml
+++ b/src/Samples/XAML_Controls/Xaml_Controls.xaml
@@ -25,30 +25,30 @@
             </ItemsControl.ItemsPanel>
             
             <local:TreeView_Demo HorizontalAlignment="Center"/>
-            <local:TreeMap_Demo/>
-            <local:InkPresenter_Demo/>
+            <local:TreeMap_Demo HorizontalAlignment="Center"/>
+            <local:InkPresenter_Demo HorizontalAlignment="Center"/>
             <local:Button_Demo HorizontalAlignment="Center"/>
-            <local:ButtonSpinner_Demo/>
+            <local:ButtonSpinner_Demo HorizontalAlignment="Center"/>
             <local:TextBox_Demo HorizontalAlignment="Center"/>
             <local:CheckBox_Demo HorizontalAlignment="Center"/>
             <local:RadioButton_Demo HorizontalAlignment="Center"/>
             <local:TextBlock_Demo HorizontalAlignment="Center"/>
             <local:Label_Demo HorizontalAlignment="Center"/>
-            <local:RichTextBlock_Demo/>
-            <local:RichTextBox_Demo/>
+            <local:RichTextBlock_Demo HorizontalAlignment="Center"/>
+            <local:RichTextBox_Demo HorizontalAlignment="Center"/>
             <local:Path_Demo HorizontalAlignment="Center"/>
-            <local:ProgressBar_Demo/>
+            <local:ProgressBar_Demo HorizontalAlignment="Center"/>
             <local:DataForm_Demo HorizontalAlignment="Center"/>
             <local:BusyIndicator_Demo HorizontalAlignment="Center"/>
             <local:ToolTip_Demo HorizontalAlignment="Center"/>
             <local:HyperlinkButton_Demo HorizontalAlignment="Center"/>
             <local:NumericUpDown_Demo HorizontalAlignment="Center"/>
-            <local:DomainUpDown_Demo/>
-            <local:UpDownBase_Demo/>
+            <local:DomainUpDown_Demo HorizontalAlignment="Center"/>
+            <local:UpDownBase_Demo HorizontalAlignment="Center"/>
             <local:ComboBox_Demo x:Name="ComboBoxDemo" HorizontalAlignment="Center"/>
             <local:RepeatButton_Demo HorizontalAlignment="Center"/>
             <local:ListBox_Demo x:Name="ListBoxDemo" HorizontalAlignment="Center"/>
-            <local:ItemsControl_Demo/>
+            <local:ItemsControl_Demo HorizontalAlignment="Center"/>
             <local:Slider_Demo HorizontalAlignment="Center"/>
             <local:ToggleButton_Demo HorizontalAlignment="Center"/>
             <local:PasswordBox_Demo HorizontalAlignment="Center"/>
@@ -62,12 +62,12 @@
             <local:Thumb_Demo x:Name="ThumbDemo" HorizontalAlignment="Center"/>
             <local:Shapes_Demo HorizontalAlignment="Center"/>
             <local:DatePicker_Demo x:Name="DatePickerDemo" HorizontalAlignment="Center"/>
-            <local:TimePicker_Demo/>
-            <local:Calendar_Demo/>
-            <local:GlobalCalendar_Demo/>
-            <local:Rating_Demo/>
+            <local:TimePicker_Demo HorizontalAlignment="Center"/>
+            <local:Calendar_Demo HorizontalAlignment="Center"/>
+            <local:GlobalCalendar_Demo HorizontalAlignment="Center"/>
+            <local:Rating_Demo HorizontalAlignment="Center"/>
             <local:ContextMenu_MenuItem_Demo x:Name="MenuItemDemo" HorizontalAlignment="Center"/>
-            <local:AnimatedNavigationBar_Demo/>
+            <local:AnimatedNavigationBar_Demo HorizontalAlignment="Center"/>
         </ItemsControl>
     </StackPanel>
 </Page>

--- a/src/Samples/XAML_Controls/Xaml_Controls.xaml.cs
+++ b/src/Samples/XAML_Controls/Xaml_Controls.xaml.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Net;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Controls.Primitives;
-using System.Windows.Media;
-using System.Windows.Media.Effects;
 
 namespace OpenSilver.Samples.Showcase;
 
@@ -15,6 +10,6 @@ public partial class Xaml_Controls : Page
         InitializeComponent();
 
         var dataGridDemoIndex = SamplesPanel.Items.IndexOf(DataGridDemo);
-        SamplesPanel.Items.Insert(dataGridDemoIndex, new DataGridGrouping());
+        SamplesPanel.Items.Insert(dataGridDemoIndex, new DataGridGrouping { HorizontalAlignment = HorizontalAlignment.Center });
     }
 }

--- a/src/Samples/XAML_Features/XAML_Features.xaml
+++ b/src/Samples/XAML_Features/XAML_Features.xaml
@@ -30,21 +30,21 @@
             <local:Binding1_Demo x:Name="Binding1Demo" HorizontalAlignment="Center"/>
             <local:Binding2_Demo HorizontalAlignment="Center"/>
             <local:Binding3_Demo HorizontalAlignment="Center"/>
-            <local:MultiBinding_Demo/>
-            <local:Command_Demo/>
+            <local:MultiBinding_Demo HorizontalAlignment="Center"/>
+            <local:Command_Demo HorizontalAlignment="Center"/>
             <local:Gradients_Demo HorizontalAlignment="Center"/>
-            <local:Styles_Demo/>
-            <local:Themes_Demo/>
-            <local:Triggers_Demo/>
-            <local:XamlReader_Demo/>
+            <local:Styles_Demo HorizontalAlignment="Center"/>
+            <local:Themes_Demo HorizontalAlignment="Center"/>
+            <local:Triggers_Demo HorizontalAlignment="Center"/>
+            <local:XamlReader_Demo HorizontalAlignment="Center"/>
             <local:Animations_Demo HorizontalAlignment="Center"/>
-            <local:AnimationTool_Demo/>
+            <local:AnimationTool_Demo HorizontalAlignment="Center"/>
             <local:DropShadowEffect_Demo HorizontalAlignment="Center"/>
-            <local:BlurEffect_Demo/>
-            <local:ImageBrush_Demo/>
+            <local:BlurEffect_Demo HorizontalAlignment="Center"/>
+            <local:ImageBrush_Demo HorizontalAlignment="Center"/>
             <local:Window_SizeChanged_Demo HorizontalAlignment="Center"/>
             <local:FindElementsInHostCoordinates_Demo HorizontalAlignment="Center"/>
-            <local:TransformToVisual_Demo/>
+            <local:TransformToVisual_Demo HorizontalAlignment="Center"/>
             <local:ClipToBounds_Demo HorizontalAlignment="Center"/>
             <local:Validation_Demo HorizontalAlignment="Center"/>
             <local:MouseWheel_Demo HorizontalAlignment="Center"/>
@@ -56,11 +56,10 @@
             <local:MarkupExtensions_Demo x:Name="MarkupExtensionsDemo" HorizontalAlignment="Center"/>
             <local:UriMapper_Demo HorizontalAlignment="Center"/>
             <local:PropertyChangedTrigger_Demo HorizontalAlignment="Center"/>
-            <local:Behaviors_Demo/>
-            <local:Clipping_Demo/>
-            <local:Cursor_Demo/>
-            <local:FlowDirection_Demo/>
-            
+            <local:Behaviors_Demo HorizontalAlignment="Center"/>
+            <local:Clipping_Demo HorizontalAlignment="Center"/>
+            <local:Cursor_Demo HorizontalAlignment="Center"/>
+            <local:FlowDirection_Demo HorizontalAlignment="Center"/>            
         </ItemsControl>
     </StackPanel>
 </Page>

--- a/src/Samples/XAML_Layout/Xaml_Layout.xaml
+++ b/src/Samples/XAML_Layout/Xaml_Layout.xaml
@@ -18,7 +18,7 @@
         <ItemsControl x:Name="SamplesPanel" local:ItemsControlLoadingBehavior.ShowLoadingOnGenerating="True">
             <ItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>
-                    <controlskit:StaggeredPanel ProgressiveRenderingChunkSize="2"/>
+                    <controlskit:StaggeredPanel ProgressiveRenderingChunkSize="2" DesiredColumnWidth="280"/>
                 </ItemsPanelTemplate>
             </ItemsControl.ItemsPanel>
 

--- a/src/Samples/XAML_Layout/Xaml_Layout.xaml
+++ b/src/Samples/XAML_Layout/Xaml_Layout.xaml
@@ -23,12 +23,12 @@
             </ItemsControl.ItemsPanel>
 
             <local:Grid_Demo HorizontalAlignment="Center"/>
-            <local:UniformGrid_Demo/>
+            <local:UniformGrid_Demo HorizontalAlignment="Center"/>
             <local:StackPanel_Demo HorizontalAlignment="Center"/>
             <local:DockPanel_Demo HorizontalAlignment="Center"/>
             <local:WrapPanel_Demo HorizontalAlignment="Center"/>
             <local:Canvas_Demo HorizontalAlignment="Center"/>
-            <local:MeasureArrange_Demo/>
+            <local:MeasureArrange_Demo HorizontalAlignment="Center"/>
             <local:Border_Demo HorizontalAlignment="Center"/>
             <local:ScrollViewer_Demo x:Name="ScrollViewerDemo" HorizontalAlignment="Center"/>
             <local:GridSplitter_Demo HorizontalAlignment="Center"/>
@@ -36,14 +36,13 @@
             <local:ChildWindow_Demo HorizontalAlignment="Center"/>
             <local:NonModalChildWindow_Demo x:Name="NonModalChildWindow" HorizontalAlignment="Center"/>
             <local:Expander_Demo HorizontalAlignment="Center"/>
-            <local:HeaderedContentControl_Demo/>
-            <local:Accordion_Demo/>
+            <local:HeaderedContentControl_Demo HorizontalAlignment="Center"/>
+            <local:Accordion_Demo HorizontalAlignment="Center"/>
             <local:Popup_Demo HorizontalAlignment="Center"/>
             <local:Frame_Demo x:Name="FrameDemo" HorizontalAlignment="Center"/>
             <local:Viewbox_Demo HorizontalAlignment="Center"/>
-            <local:TransitioningContentControl_Demo/>
-            <local:LayoutTransformer_Demo/>
-
+            <local:TransitioningContentControl_Demo HorizontalAlignment="Center"/>
+            <local:LayoutTransformer_Demo HorizontalAlignment="Center"/>
         </ItemsControl>
     </StackPanel>
 </Page>


### PR DESCRIPTION
- Use fixed StaggeredPanel
- Align all the cards horizontally by center
- Workaround to not clip card headers on narrow screens
- Improve desired column width