### PR TITLE
Reduce left margin on mobile so that samples are properly centered when the left menu is collapsed

### DIFF
--- a/src/Other/Styles.xaml
+++ b/src/Other/Styles.xaml
@@ -16,7 +16,7 @@
 
     <Style x:Key="Page_Style" TargetType="Page">
         <Style.Setters>
-            <Setter Property="Margin" Value="20,0,0,0"/>
+            <Setter Property="Margin" Value="{Responsive Mobile='4,0,0,30', Tablet='20,0,0,30'}"/>
         </Style.Setters>
     </Style>
     <Style x:Key="PageIntroText_Style" TargetType="TextBlock">


### PR DESCRIPTION
**BEFORE:**

![image](https://github.com/user-attachments/assets/c8d1bad1-e3de-49ed-bd2c-d8a97719c0c1)

**AFTER:**

![image](https://github.com/user-attachments/assets/317e0923-47db-4daf-af4d-ac76f39df247)

